### PR TITLE
JSON Parse Issues

### DIFF
--- a/src/cxm.coffee
+++ b/src/cxm.coffee
@@ -31,7 +31,7 @@ class Cxm
         .catch (response) ->
             message = "CXM API returned HTTP error #{response.statusCode}"
             if response.error
-                error = JSON.parse response.error
+                error = response.error
                 message += ": #{error.message}" if error.message
             return Promise.reject message: message, errorCode: response.statusCode
 


### PR DESCRIPTION
When an exception is thrown, it's trying to parse a JSON string which is already an object, resulting in the following error: `Uncaught SyntaxError: Unexpected token o`. Removing the double parsing fixes this issue.
